### PR TITLE
Move to a 2×2 grid of count inputs for SR2025

### DIFF
--- a/comp25/score-sheet-2025.svg
+++ b/comp25/score-sheet-2025.svg
@@ -188,13 +188,13 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.0002004"
-     inkscape:cx="412.41735"
-     inkscape:cy="40.491885"
+     inkscape:cx="424.91485"
+     inkscape:cy="667.86616"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1920"
-     inkscape:window-height="984"
+     inkscape:window-height="1163"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -305,24 +305,24 @@
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#4d4d4d;fill-opacity:1;stroke:none"
          x="566.37341"
-         y="913.14142"
+         y="898.14142"
          id="text11431"><tspan
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.5px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'"
            id="tspan3088"
            sodipodi:role="line"
            x="566.37341"
-           y="913.14142"><tspan
+           y="898.14142"><tspan
    style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.5px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'"
    id="zone-3-label">Zone 3 </tspan>(yellow)</tspan></text>
       <text
          id="text11447"
-         y="913.14142"
+         y="898.14142"
          x="176.78113"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#4d4d4d;fill-opacity:1;stroke:none"
          xml:space="preserve"><tspan
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.5px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;text-anchor:middle"
            id="tspan3090"
-           y="913.14142"
+           y="898.14142"
            x="176.78113"
            sodipodi:role="line"><tspan
    style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.5px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'"
@@ -383,7 +383,7 @@
       <use
          height="1052.3622"
          width="744.09448"
-         transform="translate(-10e-7,664.39824)"
+         transform="translate(-10e-7,649.39824)"
          id="use3574"
          xlink:href="#text3416"
          y="0"
@@ -391,7 +391,7 @@
       <use
          height="1052.3622"
          width="744.09448"
-         transform="translate(-10e-7,664.39824)"
+         transform="translate(-10e-7,649.39824)"
          id="use3580"
          xlink:href="#use3566"
          y="0"
@@ -399,7 +399,7 @@
       <use
          height="1052.3622"
          width="744.09448"
-         transform="translate(-10e-7,664.39823)"
+         transform="translate(-10e-7,649.39823)"
          id="use3576"
          xlink:href="#text3412-5"
          y="0"
@@ -407,7 +407,7 @@
       <use
          height="1052.3622"
          width="744.09448"
-         transform="translate(-10e-7,664.39823)"
+         transform="translate(-10e-7,649.39823)"
          id="use3582"
          xlink:href="#use3570"
          y="0"
@@ -430,12 +430,12 @@
     </g>
     <g
        id="g4314"
-       transform="matrix(1.1865519,0,0,1.1865519,-44.354818,-160.57973)">
+       transform="matrix(1.1865519,0,0,1.1865519,-44.354818,-168.07973)">
       <rect
          y="344.97412"
          x="136.06934"
          height="471.95575"
-         width="471.95575"
+         width="471.95551"
          id="rect3157-35"
          style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.617315;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       <g
@@ -676,25 +676,34 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;line-height:0%;font-family:'Rockwell Extra Bold';-inkscape-font-specification:'Rockwell Extra Bold, Ultra-Bold';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"
+       style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:17.49999991px;line-height:0%;font-family:'Rockwell Extra Bold';-inkscape-font-specification:'Rockwell Extra Bold, Ultra-Bold';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"
        x="372.61487"
-       y="947.11218"
+       y="928.36218"
        id="text3223"><tspan
          sodipodi:role="line"
          x="372.61487"
-         y="947.11218"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.75px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;text-anchor:middle;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"
-         id="tspan3092">Write a block-capital letter for the colour of <tspan
-   style="font-style:italic;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"
-   id="tspan4446">token</tspan>:</tspan><tspan
+         y="928.36218"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.49999991px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;text-anchor:middle;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"
+         id="tspan3092"><tspan
+   style="font-style:italic;font-size:17.49999991px"
+   id="tspan5486">Highest</tspan>: write a block-capital letter for the colour of <tspan
+   style="font-style:italic;font-size:17.49999991px;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"
+   id="tspan4446">pallet.</tspan></tspan><tspan
          sodipodi:role="line"
          x="372.61487"
-         y="970.54968"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.75px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;text-anchor:middle;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"
-         id="tspan3994">G = green, O = orange, P = pink, Y = yellow</tspan></text>
+         y="951.79968"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.49999991px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;text-anchor:middle;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"
+         id="tspan6567">G = green, O = orange, P = pink, Y = yellow</tspan><tspan
+         sodipodi:role="line"
+         x="372.61487"
+         y="975.23718"
+         style="font-style:italic;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.49999991px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;text-anchor:middle;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"
+         id="tspan6573">G/O/P/Y<tspan
+   style="font-style:normal;font-size:17.49999991px"
+   id="tspan6575">: write the number of pallets of that colour (including the highest)</tspan></tspan></text>
     <g
        id="g6494"
-       transform="translate(-2.901489,-11.25)">
+       transform="translate(-2.901489,-18.75)">
       <text
          xml:space="preserve"
          style="font-style:normal;font-weight:normal;font-size:20px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.9375;stroke-miterlimit:4;stroke-dasharray:none"

--- a/comp25/score-sheet-2025.svg
+++ b/comp25/score-sheet-2025.svg
@@ -472,66 +472,123 @@
              id="scoring-box-outline"
              style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.493855;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
           <g
-             transform="translate(-355.86999,115.56821)"
-             id="g4902">
+             transform="translate(13.450109,-17.442693)"
+             id="g4514">
             <g
-               transform="translate(286.52111,-70.447128)"
-               id="g4717">
-              <g
-                 transform="translate(82.798989,-59.382152)"
-                 id="g4514">
-                <g
-                   id="g1084">
-                  <text
-                     id="text4699"
-                     y="376.50681"
-                     x="157.07617"
-                     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.5882px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#5a5a5a;fill-opacity:1;stroke:none"
-                     xml:space="preserve"><tspan
-                       id="tspan4701"
-                       y="376.50681"
-                       x="157.07617"
-                       sodipodi:role="line"
-                       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';fill:#5a5a5a;fill-opacity:1">Highest:</tspan></text>
-                  <path
-                     style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
-                     d="m 180.30936,377.16256 h 24.83007"
-                     id="path4266-3"
-                     inkscape:connector-curvature="0"
-                     sodipodi:nodetypes="cc" />
-                </g>
-                <g
-                   id="g2915-3"
-                   transform="translate(-0.32927529,29.497235)">
-                  <text
-                     id="text4699-6"
-                     y="372.8197"
-                     x="160.23459"
-                     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.5882px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#5a5a5a;fill-opacity:1;stroke:none"
-                     xml:space="preserve"><tspan
-                       id="tspan4701-7"
-                       y="372.8197"
-                       x="160.23459"
-                       sodipodi:role="line"
-                       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';fill:#5a5a5a;fill-opacity:1">Pallets:</tspan></text>
-                  <path
-                     style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
-                     d="m 134.58068,406.65979 h 72.8082"
-                     id="path4266-3-5"
-                     inkscape:connector-curvature="0"
-                     sodipodi:nodetypes="cc" />
-                  <path
-                     style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
-                     d="m 134.58068,389.80423 h 72.8082"
-                     id="path4266-3-5-3"
-                     inkscape:connector-curvature="0"
-                     sodipodi:nodetypes="cc" />
-                </g>
-                <g
-                   transform="translate(-11.282429,-22.272081)"
-                   id="use4478" />
-              </g>
+               id="g1084">
+              <text
+                 id="text4699"
+                 y="376.50681"
+                 x="178.12222"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.5882px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#5a5a5a;fill-opacity:1;stroke:none"
+                 xml:space="preserve"><tspan
+                   id="tspan4701"
+                   y="376.50681"
+                   x="157.07617"
+                   sodipodi:role="line"
+                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';fill:#5a5a5a;fill-opacity:1;text-anchor:end;text-align:end">Highest:</tspan></text>
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 180.30936,377.16256 h 24.83007"
+                 id="path4266-3"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="cc" />
             </g>
+          </g>
+          <g
+             id="g15920"
+             transform="translate(-0.62976725)">
+            <g
+               transform="translate(19.244205,32.559051)"
+               id="district-yellow-input">
+              <text
+                 id="text4699-3"
+                 y="376.50681"
+                 x="178.12222"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.5882px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#5a5a5a;fill-opacity:1;stroke:none"
+                 xml:space="preserve"><tspan
+                   id="tspan4701-6"
+                   y="376.50681"
+                   x="178.12222"
+                   sodipodi:role="line"
+                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;text-anchor:end;fill:#5a5a5a;fill-opacity:1">Y:</tspan></text>
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 180.30936,377.16256 h 24.83007"
+                 id="path4266-3-1"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="cc" />
+            </g>
+            <g
+               transform="translate(18.924511,7.2700483)"
+               id="district-pink-input">
+              <text
+                 id="text4699-3-1"
+                 y="376.50681"
+                 x="178.12222"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.5882px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#5a5a5a;fill-opacity:1;stroke:none"
+                 xml:space="preserve"><tspan
+                   id="tspan4701-6-9"
+                   y="376.50681"
+                   x="178.12222"
+                   sodipodi:role="line"
+                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;text-anchor:end;fill:#5a5a5a;fill-opacity:1">P:</tspan></text>
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 180.30936,377.16256 h 24.83007"
+                 id="path4266-3-1-4"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="cc" />
+            </g>
+            <g
+               transform="translate(-21.684545,7.3351188)"
+               id="district-orange-input">
+              <text
+                 id="text4699-3-5"
+                 y="376.50681"
+                 x="178.12222"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.5882px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#5a5a5a;fill-opacity:1;stroke:none"
+                 xml:space="preserve"><tspan
+                   id="tspan4701-6-0"
+                   y="376.50681"
+                   x="178.12222"
+                   sodipodi:role="line"
+                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;text-anchor:end;fill:#5a5a5a;fill-opacity:1">O:</tspan></text>
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 180.30936,377.16256 h 24.83007"
+                 id="path4266-3-1-3"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="cc" />
+            </g>
+            <g
+               transform="translate(-21.978777,32.618463)"
+               id="district-green-input">
+              <text
+                 id="text4699-3-1-6"
+                 y="376.50681"
+                 x="178.12222"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.5882px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#5a5a5a;fill-opacity:1;stroke:none"
+                 xml:space="preserve"><tspan
+                   id="tspan4701-6-9-3"
+                   y="376.50681"
+                   x="178.12222"
+                   sodipodi:role="line"
+                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;text-anchor:end;fill:#5a5a5a;fill-opacity:1">G:</tspan></text>
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 180.30936,377.16256 h 24.83007"
+                 id="path4266-3-1-4-2"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="cc" />
+            </g>
+          </g>
+          <g
+             transform="translate(34.519559,28.910102)"
+             id="g4514-2">
+            <g
+               transform="translate(-11.282429,-22.272081)"
+               id="use4478-9" />
           </g>
         </g>
         <text

--- a/comp25/score-sheet-2025.svg
+++ b/comp25/score-sheet-2025.svg
@@ -472,7 +472,7 @@
              id="scoring-box-outline"
              style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.493855;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
           <g
-             transform="translate(13.450109,-17.442693)"
+             transform="translate(13.450109,-12.702066)"
              id="g4514">
             <g
                id="g1084">
@@ -484,9 +484,9 @@
                  xml:space="preserve"><tspan
                    id="tspan4701"
                    y="376.50681"
-                   x="157.07617"
+                   x="178.12222"
                    sodipodi:role="line"
-                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';fill:#5a5a5a;fill-opacity:1;text-anchor:end;text-align:end">Highest:</tspan></text>
+                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;text-anchor:end;fill:#5a5a5a;fill-opacity:1">Highest:</tspan></text>
               <path
                  style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
                  d="m 180.30936,377.16256 h 24.83007"
@@ -496,31 +496,10 @@
             </g>
           </g>
           <g
-             id="g15920"
-             transform="translate(-0.62976725)">
+             id="g995"
+             transform="translate(0,-0.23432115)">
             <g
-               transform="translate(19.244205,32.559051)"
-               id="district-yellow-input">
-              <text
-                 id="text4699-3"
-                 y="376.50681"
-                 x="178.12222"
-                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.5882px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#5a5a5a;fill-opacity:1;stroke:none"
-                 xml:space="preserve"><tspan
-                   id="tspan4701-6"
-                   y="376.50681"
-                   x="178.12222"
-                   sodipodi:role="line"
-                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;text-anchor:end;fill:#5a5a5a;fill-opacity:1">Y:</tspan></text>
-              <path
-                 style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
-                 d="m 180.30936,377.16256 h 24.83007"
-                 id="path4266-3-1"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cc" />
-            </g>
-            <g
-               transform="translate(18.924511,7.2700483)"
+               transform="translate(18.294744,15.171093)"
                id="district-pink-input">
               <text
                  id="text4699-3-1"
@@ -541,7 +520,7 @@
                  sodipodi:nodetypes="cc" />
             </g>
             <g
-               transform="translate(-21.684545,7.3351188)"
+               transform="translate(-22.314312,15.236164)"
                id="district-orange-input">
               <text
                  id="text4699-3-5"
@@ -561,8 +540,32 @@
                  inkscape:connector-curvature="0"
                  sodipodi:nodetypes="cc" />
             </g>
+          </g>
+          <g
+             id="g1005">
             <g
-               transform="translate(-21.978777,32.618463)"
+               transform="translate(18.614438,42.040305)"
+               id="district-yellow-input">
+              <text
+                 id="text4699-3"
+                 y="376.50681"
+                 x="178.12222"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.5882px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#5a5a5a;fill-opacity:1;stroke:none"
+                 xml:space="preserve"><tspan
+                   id="tspan4701-6"
+                   y="376.50681"
+                   x="178.12222"
+                   sodipodi:role="line"
+                   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.5882px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:end;text-anchor:end;fill:#5a5a5a;fill-opacity:1">Y:</tspan></text>
+              <path
+                 style="fill:none;fill-rule:evenodd;stroke:#646464;stroke-width:1.05131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05131, 1.05131;stroke-dashoffset:0;stroke-opacity:1"
+                 d="m 180.30936,377.16256 h 24.83007"
+                 id="path4266-3-1"
+                 inkscape:connector-curvature="0"
+                 sodipodi:nodetypes="cc" />
+            </g>
+            <g
+               transform="translate(-22.608544,42.099717)"
                id="district-green-input">
               <text
                  id="text4699-3-1-6"


### PR DESCRIPTION
Following some [testing with paper score-sheets](https://studentrobotics.slack.com/archives/CCVCJ0CR5/p1732360791796149?thread_ts=1727735398.350019&cid=CCVCJ0CR5) at the Tech Day yesterday we think that this design works better. It's had some small tweaks from the variant which was tested, though all based on what we learned during that testing.

![score-sheet-2025](https://github.com/user-attachments/assets/50ec9a78-5171-45c5-9acb-42c93501e086)
